### PR TITLE
Add another player info guess when finalizing.

### DIFF
--- a/src/tracker.pm
+++ b/src/tracker.pm
@@ -52,6 +52,7 @@ sub finalize {
         }
     }
     $game{acting}->clear_empty_actions();
+    my %faction_info_usernames = map { $faction_info->{$_}->{username} => $_ } keys $faction_info;
 
     for my $faction ($game{acting}->factions_in_order()) {
         if ($faction->{waiting}) {
@@ -68,9 +69,12 @@ sub finalize {
                 });
         }
         my $faction_count = $game{acting}->faction_count();
+        my $player_index = %faction_info_usernames{$faction->{username}};
         my $info;
         if (exists $faction_info->{$faction->{name}}) {
             $info = $faction_info->{$faction->{name}};
+        } elsif (exists $faction_info->{$player_index}) {
+            $info = $faction_info->{$player_index};
         } elsif (exists $faction_info->{"player${faction_count}"}) {
             $info = $faction_info->{"player${faction_count}"}
         }

--- a/src/tracker.pm
+++ b/src/tracker.pm
@@ -52,7 +52,7 @@ sub finalize {
         }
     }
     $game{acting}->clear_empty_actions();
-    my %faction_info_usernames = map { $faction_info->{$_}->{username} => $_ } keys $faction_info;
+    my %faction_info_usernames = map { $faction_info->{$_}->{username} => $_ } keys %{$faction_info};
 
     for my $faction ($game{acting}->factions_in_order()) {
         if ($faction->{waiting}) {
@@ -69,7 +69,7 @@ sub finalize {
                 });
         }
         my $faction_count = $game{acting}->faction_count();
-        my $player_index = %faction_info_usernames{$faction->{username}};
+        my $player_index = $faction_info_usernames{$faction->{username}};
         my $info;
         if (exists $faction_info->{$faction->{name}}) {
             $info = $faction_info->{$faction->{name}};


### PR DESCRIPTION
During `terra_mystica::finalize`, `faction_count()` is used as a guess of the current player index. However, when a game admin edits the `setup faction` commands, this assumption can be invalid. 

This PR adds an additional guess. The additional guess tries to find the username-in-question inside `$faction_info`, which is either loaded from `game_role` (`AppendGame.pm`) or `game_player` (everywhere else). 